### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,5 @@
+v0.1.1 - 7 July 2017
+- Move from clojure.spec to clojure.spec.alpha
+
 v0.1.0 - 15 May 2017
 - First Release

--- a/build.boot
+++ b/build.boot
@@ -8,7 +8,7 @@
 
 (set-env!
   :project 'irresponsible/spectra
-  :version "0.1.0"
+  :version "0.1.1"
   :resource-paths #{"src" "resources"}
   :source-paths #{"src"}
   :repositories #(conj % ["clojars" {:url "https://clojars.org/repo/"}])


### PR DESCRIPTION
Moved from `clojure.spec` to the newer `clojure.spec.alpha`.